### PR TITLE
added features clamping and rotation of button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-This is a fork of the great [React Rotary Knob](https://hugozap.github.io/react-rotary-knob) library by [hugozap](https://github.com/hugozap/react-rotary-knob).
-
-
 # 🎛 React Rotary Knob
 
 [Demo](https://hugozap.github.io/react-rotary-knob/storybook)
@@ -95,12 +92,6 @@ Props:
 | skin | Skin object| |
 | onStart | Called when the dragging starts |
 | onEnd | Called when the dragging ends |
-
-
-added Props in this fork:
-
-| Prop | Description | Default Value |
-|-----|--------------|----|
 | clampMin | degree value to move the starting point of the active area of the knob away from the center | 0 |
 | clampMax | degree value to move the end point of the active area of the knob away from the center | 360 |
 | rotateDegrees | degree value to rotate the knob component to have the starting / end points at a different position | 0 (zero is at top |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This is a fork of the great [React Rotary Knob](https://hugozap.github.io/react-rotary-knob) library by [hugozap](https://github.com/hugozap/react-rotary-knob).
+
+
 # 🎛 React Rotary Knob
 
 [Demo](https://hugozap.github.io/react-rotary-knob/storybook)
@@ -92,6 +95,16 @@ Props:
 | skin | Skin object| |
 | onStart | Called when the dragging starts |
 | onEnd | Called when the dragging ends |
+
+
+added Props in this fork:
+
+| Prop | Description | Default Value |
+|-----|--------------|----|
+| clampMin | degree value to move the starting point of the active area of the knob away from the center | 0 |
+| clampMax | degree value to move the end point of the active area of the knob away from the center | 360 |
+| rotateDegrees | degree value to rotate the knob component to have the starting / end points at a different position | 0 (zero is at top |
+
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,8 @@ type Skin = {
 type KnobProps = {
   value: ?number,
   defaultValue: ?number,
+  clampMin: ?number,
+  clampMax: ?Number,
   min: number,
   max: number,
   skin: Skin,
@@ -101,6 +103,8 @@ class Knob extends Component<KnobProps, KnobState> {
   static defaultProps = {
     min: 0,
     max: 100,
+    clampMax: 360,
+    clampMin: 0,
     onChange: function() {},
     onStart:function() {},
     onEnd: function () {},
@@ -113,6 +117,7 @@ class Knob extends Component<KnobProps, KnobState> {
     defaultValue: 0,
     step: 1
   };
+
   componentDidMount() {
     if (this.props.value == null) {
       /**
@@ -142,7 +147,8 @@ class Knob extends Component<KnobProps, KnobState> {
     if (pmin != nmin || pmax != nmax) {
       this.scale = scaleLinear()
         .domain([nmin, nmax])
-        .range([0, 359]);
+        .range([this.props.clampMax, this.props.clampMin]);
+        this.scale.clamp(true);
     }
   }
 
@@ -202,7 +208,7 @@ class Knob extends Component<KnobProps, KnobState> {
       let startPos = { x: event.x - cx, y: event.y - cy };
       let startAngle = utils.getAngleForPoint(startPos.x, startPos.y);
       let lastPos = startPos;
-      let lastAngle = utils.getAngleForPoint(lastPos.x, lastPos.y);
+      //let lastAngle = utils.getAngleForPoint(lastPos.x, lastPos.y);
       //in precise mode, we won't monitor angle change unless the distance > unlockDistance
       let monitoring = false;
       self.setState({
@@ -239,7 +245,6 @@ class Knob extends Component<KnobProps, KnobState> {
 
         lastPos = currentPos;
         let finalAngle = initialAngle + deltaAngle;
-
         if (finalAngle < 0) {
           //E.g -1 turns 359
           finalAngle += 360;
@@ -297,7 +302,9 @@ class Knob extends Component<KnobProps, KnobState> {
   componentWillMount() {
     this.scale = scaleLinear()
       .domain([this.props.min, this.props.max])
-      .range([0, 360]);
+      .range([this.props.clampMax, this.props.clampMin]);
+      
+      this.scale.clamp(true);
   }
 
   onFormControlChange(newVal: number) {

--- a/src/index.js
+++ b/src/index.js
@@ -324,6 +324,8 @@ class Knob extends Component<KnobProps, KnobState> {
       defaultValue,
       min,
       max,
+      clampMax,
+      clampMin,
       onChange,
       onStart,
       onEnd,

--- a/stories/index.js
+++ b/stories/index.js
@@ -239,6 +239,60 @@ stories.add("ClampMax and ClampMin", () => {
   );
 });
 
+
+stories.add("Rotate", () => {
+  return (
+    <div>
+      <p>
+        change rotateDegrees prop to degree value to rotate the knob
+      </p>
+      <Knob
+      
+      skin={textskin}
+        
+        style={{
+          width: "80px",
+          margin: "8rem",
+          height: "80px",
+          display: "inline-block"
+        }}
+        min={0}
+        max={100}
+        rotateDegrees={160}
+      />
+    </div>
+  );
+});
+
+
+stories.add("Rotate + Clamping", () => {
+  return (
+    <div>
+      <p>
+        Knob rotated by 180 degrees, with clampMin = 30 and clampMax = 330
+      </p>
+      <Knob
+      
+      skin={textskin}
+        
+        style={{
+          width: "80px",
+          margin: "8rem",
+          height: "80px",
+          display: "inline-block"
+        }}
+        min={0}
+        max={100}
+        rotateDegrees={180}
+        clampMin={20}
+        clampMax={340}
+      />
+    </div>
+  );
+});
+
+
+
 stories.add('Start value set, text skin', ()=>{
  
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -61,22 +61,24 @@ stories.add("Basic", () => {
     return (
       <div>
         
-        <h2>{this.state.value.toFixed(2)} </h2>
+        <h2>{this.state.value.toFixed(2)} </h2> 
 
         <Knob
-          style={{
-            width: "80px",
-            marginTop: "8rem",
-            marginLeft: "8rem",
-            height: "80px",
-            display: "inline-block"
-          }}
-          onChange={val => {
-            this.changeValue(val);
-          }}
-          min={0}
-          max={100}
-          value={this.state.value}
+        
+        skin={textskin}
+        
+        style={{
+          width: "80px",
+          marginTop: "8rem",
+          height: "80px",
+          display: "inline-block"
+        }}
+        onChange={val => {
+          this.changeValue(val);
+        }}
+        min={0}
+        max={100}
+        value={this.state.value}
         />
       </div>
     );
@@ -206,6 +208,32 @@ stories.add("Step = 0.1", () => {
         min={0}
         max={1}
         step={0.1}
+      />
+    </div>
+  );
+});
+
+
+stories.add("ClampMax and ClampMin", () => {
+  return (
+    <div>
+      <p>
+        change clampMax and clampMin props to degree values to limit the range of the knob (e.g. clampMin = 20, clampMax = 340 will give a 40 degree gap between max and min)
+      </p>
+      <Knob
+      
+      skin={textskin}
+        
+        style={{
+          width: "80px",
+          marginTop: "8rem",
+          height: "80px",
+          display: "inline-block"
+        }}
+        min={0}
+        max={1}
+        clampMax={300}
+        clampMin={60}
       />
     </div>
   );


### PR DESCRIPTION
added props `clampMin` and `clampMax` to limit the range of rotation of the knob. This way you can configure the knob so not use the full range of the circle.
added prop `rotateDegrees` to be able to rotate the complete knob by specified degrees. This way you can have the minimum/maximum at the bottom instead of the top. The knob automatically adjusts the max/min values when it is rotated upside down, so the feeling of direction is preserved.

